### PR TITLE
Fix warnings/errors

### DIFF
--- a/src/App/shared/components/Footer.js
+++ b/src/App/shared/components/Footer.js
@@ -47,8 +47,8 @@ const FooterBox = styled(Box)`
 function Footer() {
   return (
     <FooterBox>
-      <Segment.Group horizontal inverted>
-        <Segment className='sides'/>
+      <Segment.Group horizontal>
+        <Segment className="sides" />
         <Segment>
           <Link to="https://pages.semanticscholar.org/coronavirus-research">
             COVID-19 Open Research Dataset (CORD-19)
@@ -63,9 +63,9 @@ function Footer() {
             Apache License 2.0
           </Link>
         </Segment>
-        <Segment className='sides'>
+        <Segment className="sides">
           <Link to="/">
-            <Image src={logo} />{' '}
+            <Image src={logo} />
           </Link>
         </Segment>
       </Segment.Group>

--- a/src/App/shared/components/NavMenu.js
+++ b/src/App/shared/components/NavMenu.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { Box } from 'rebass';
 import { Menu } from 'semantic-ui-react';
 import Link from 'App/shared/components/Link';
-import logo from 'App/shared/img/VespaLogoWhite.png';
 
 const NavBar = styled(Menu)`
   &&& {
@@ -39,9 +38,7 @@ function NavMenu() {
     <Box sx={{ paddingLeft: '16px', paddingRight: '16px' }} width={1}>
       <NavBar secondary inverted fluid>
         <Menu.Item header>
-          <Link to="/">
-            CORD-19 Search and Navigate
-          </Link>
+          <Link to="/">CORD-19 Search and Navigate</Link>
         </Menu.Item>
         <Menu.Menu position="right">
           <Menu.Item>


### PR DESCRIPTION
An error and warning introduced in #39
```
Warning: Received `true` for a non-boolean attribute `inverted`.

If you want to write it to the DOM, pass a string instead: inverted="true" or inverted={value.toString()}.
    in div (created by SegmentGroup)
    in SegmentGroup (at Footer.js:50)
    in div (created by Context.Consumer)
    in Styled(div) (created by Context.Consumer)
    in StyledComponent (created by Styled(Styled(div)))
    in Styled(Styled(div)) (at Footer.js:49)
    in Footer (at App/index.js:25)
    in div (created by Context.Consumer)
    in Styled(div) (at App/index.js:13)
    in App (at src/index.js:13)
  Line 6:8:  'logo' is defined but never used  no-unused-vars
```
Fails build: https://github.com/vespa-engine/cord-19/runs/548925021?check_suite_focus=true

We need PR builds! 