### PR TITLE
Make rank profile explicit to handle backend not enforcing rank profile

### DIFF
--- a/src/App/Article/index.js
+++ b/src/App/Article/index.js
@@ -97,7 +97,9 @@ function Related({ id }) {
   query.set('id', id);
   query.set('searchChain', 'related-ann');
   query.set('summary', 'short');
-  query.set('hits', '3');
+  query.set('ranking.profile', 'related-ann');
+  query.set('use-abstract', 'true');
+  query.set('hits', '5');
 
   const { loading, response, error } = Get(
     '/search/?' + query.toString()


### PR DESCRIPTION
List 5 instead of 3, make ranking profile explicit and include abstract embedding vectors in the similarity NN search. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
