### PR TITLE
Add new Similarity method using SPECTER paper embeddings 

### DIFF
--- a/src/App/Article/index.js
+++ b/src/App/Article/index.js
@@ -106,8 +106,7 @@ function Related({ id, specter }) {
   query.set('id', id);
   query.set('summary', 'short');
   query.set('hits', 5);
-  if (specter)
-    query.set('use-specter', true)
+  if (specter) query.set('use-specter', true);
   const { loading, response, error } = Get(
     '/search/?' + query.toString()
   ).state();
@@ -124,7 +123,9 @@ function Related({ id, specter }) {
         {response.root.children.map((article, i) => (
           <ResultCard key={i} {...article} />
         ))}
-        <Link to={`/search/?query=related_to:${id}&use-specter=${specter}`}>Show more</Link>
+        <Link to={`/search/?query=related_to:${id}&use-specter=${specter}`}>
+          Show more
+        </Link>
       </React.Fragment>
     </Tab.Pane>
   );

--- a/src/App/Article/index.js
+++ b/src/App/Article/index.js
@@ -101,15 +101,13 @@ function Content({
   );
 }
 
-function Related({ id }) {
+function Related({ id, specter }) {
   const query = new URLSearchParams();
   query.set('id', id);
-  query.set('searchChain', 'related-ann');
   query.set('summary', 'short');
-  query.set('ranking.profile', 'related-ann');
-  query.set('use-abstract', true);
   query.set('hits', 5);
-
+  if (specter)
+    query.set('use-specter', true)
   const { loading, response, error } = Get(
     '/search/?' + query.toString()
   ).state();
@@ -126,7 +124,7 @@ function Related({ id }) {
         {response.root.children.map((article, i) => (
           <ResultCard key={i} {...article} />
         ))}
-        <Link to={`/search/?query=related_to:${id}`}>Show more</Link>
+        <Link to={`/search/?query=related_to:${id}&use-specter=${specter}`}>Show more</Link>
       </React.Fragment>
     </Tab.Pane>
   );
@@ -145,7 +143,7 @@ function CitedBy({ citedBy, total, offset, onOffsetChange }) {
 
 function Citation({ id }) {
   const { loading, response, error } = Get(
-    `/document/v1/covid-19/doc/docid/${id}`
+    `/document/v1/covid-19/doc/docid/${id}?fieldSet=doc:title,abstract,doi,abstract_t5,journal,source,timestamp,license`
   ).state();
 
   if (loading) return <Loading message="Loading..." />;
@@ -177,8 +175,12 @@ function Article({ id }) {
 
   const panes = [
     {
-      menuItem: 'Similar articles',
-      render: () => <Related id={response.fields.id} />,
+      menuItem: 'Similar articles by Sent-SciBERT',
+      render: () => <Related id={response.fields.id} specter={false} />,
+    },
+    {
+      menuItem: 'Similar articles by SPECTER',
+      render: () => <Related id={response.fields.id} specter={true} />,
     },
     {
       menuItem: {

--- a/src/App/Search/SearchOptions.js
+++ b/src/App/Search/SearchOptions.js
@@ -41,6 +41,12 @@ const rankings = [
 ];
 
 function RelatedArticle({ id }) {
+  var params = new URLSearchParams(window.location.search);
+  var use_specter = params.get('use-specter'); 
+  var similarMethod = "Sent-SciBERT similarity";
+  if (use_specter == 'true')
+    similarMethod = "SPECTER similarity";
+
   const query = new URLSearchParams();
   query.set('yql', `select title from sources * where id = ${id};`);
   const { loading, response, error } = Get(
@@ -56,8 +62,8 @@ function RelatedArticle({ id }) {
 
   return (
     <Container>
-      Showing articles similar to{' '}
-      <Link to={`/article/${id}`}>{hits[0].fields.title}</Link>
+      Showing articles similar to{' '} 
+      <Link to={`/article/${id}`}>{hits[0].fields.title}</Link> by {similarMethod}. 
     </Container>
   );
 }

--- a/src/App/Search/SearchOptions.js
+++ b/src/App/Search/SearchOptions.js
@@ -42,10 +42,9 @@ const rankings = [
 
 function RelatedArticle({ id }) {
   var params = new URLSearchParams(window.location.search);
-  var use_specter = params.get('use-specter'); 
-  var similarMethod = "Sent-SciBERT similarity";
-  if (use_specter == 'true')
-    similarMethod = "SPECTER similarity";
+  var use_specter = params.get('use-specter');
+  var similarMethod = 'Sent-SciBERT similarity';
+  if (use_specter == 'true') similarMethod = 'SPECTER similarity';
 
   const query = new URLSearchParams();
   query.set('yql', `select title from sources * where id = ${id};`);
@@ -62,8 +61,9 @@ function RelatedArticle({ id }) {
 
   return (
     <Container>
-      Showing articles similar to{' '} 
-      <Link to={`/article/${id}`}>{hits[0].fields.title}</Link> by {similarMethod}. 
+      Showing articles similar to{' '}
+      <Link to={`/article/${id}`}>{hits[0].fields.title}</Link> by{' '}
+      {similarMethod}.
     </Container>
   );
 }

--- a/src/App/Search/SearchOptions.js
+++ b/src/App/Search/SearchOptions.js
@@ -41,10 +41,11 @@ const rankings = [
 ];
 
 function RelatedArticle({ id }) {
-  var params = new URLSearchParams(window.location.search);
-  var use_specter = params.get('use-specter');
-  var similarMethod = 'Sent-SciBERT similarity';
-  if (use_specter == 'true') similarMethod = 'SPECTER similarity';
+  const params = new URLSearchParams(window.location.search);
+  const use_specter = params.get('use-specter') === 'true';
+  const similarMethod = use_specter
+    ? 'SPECTER similarity'
+    : 'Sent-SciBERT similarity';
 
   const query = new URLSearchParams();
   query.set('yql', `select title from sources * where id = ${id};`);

--- a/src/App/Search/Utils.js
+++ b/src/App/Search/Utils.js
@@ -100,10 +100,10 @@ const getSearchState = () => {
     year: urlParams.getAll('year'),
     author: urlParams.getAll('author'),
     has_full_text: urlParams.getAll('has_full_text'),
-    use_specter : urlParams.getAll('use_specter'),
+    use_specter: urlParams.getAll('use_specter'),
     ranking: urlParams.get('ranking'),
     fieldset: urlParams.get('fieldset'),
-    relatedId: getRelatedId(urlParams)
+    relatedId: getRelatedId(urlParams),
   };
 };
 

--- a/src/App/Search/Utils.js
+++ b/src/App/Search/Utils.js
@@ -6,7 +6,7 @@ const select = `all(
      all(group(source) order(-count()) each(output(count())))
      all(group(journal) max(10) order(-count()) each(output(count())))
      all(group(authors.name) max(10) order(-count()) each(output(count())) as(author))
-     all(group(time.year(timestamp)) max(10) order(-count()) each(output(count())) as(year))
+     all(group(time.year(timestamp)) max(10) order(-max(time.year(timestamp))) each(output(count())) as(year))
      all(group(has_full_text) each(output(count())))
    )`
   .split('\n')
@@ -100,9 +100,10 @@ const getSearchState = () => {
     year: urlParams.getAll('year'),
     author: urlParams.getAll('author'),
     has_full_text: urlParams.getAll('has_full_text'),
+    use_specter : urlParams.getAll('use_specter'),
     ranking: urlParams.get('ranking'),
     fieldset: urlParams.get('fieldset'),
-    relatedId: getRelatedId(urlParams),
+    relatedId: getRelatedId(urlParams)
   };
 };
 


### PR DESCRIPTION
Also sort date by year in grouping, don't transfer all fields for citations (100KB per doc) and show which similarity method is used when re-directed through show-more link from article view. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
