### PR TITLE
Jobergum/ranking and examples

### DIFF
--- a/src/App/Main.js
+++ b/src/App/Main.js
@@ -45,13 +45,16 @@ const featuredArticles = [
 ];
 
 const sampleQueries = [
-  '+covid-19 +temperature impact on viral transmission',
-  'basic reproduction numbers for covid-19 in +"south korea"',
-  'Impact of school closure to handle COVID-19 pandemic',
-  '+title:"reproduction number" +abstract:MERS',
-  '+authors.name:"Neil M Ferguson"',
-  '+("SARS-COV-2" "coronavirus 2" "novel coronavirus")',
-  '+chloroquine +(covid-19 coronavirus)',
+  'What is the impact of school closure in handling the COVID-19 pandemic?',
+  'What drugs have been active against SARS-CoV or SARS-CoV-2 in animal studies?',
+  'Are there serological tests that detect antibodies to coronavirus/SARS-CoV-2?',
+  'Has social distancing had an impact on slowing the spread of COVID-19?',
+  'Are there any clinical trials available for the coronavirus/COVID-19?',
+  'What are the best masks for preventing infection by COVID-19?',
+  'Are cardiac complications likely in patients with COVID-19?',
+  'What kinds of complications related to COVID-19 are associated with hypertension?',
+  'What kinds of complications related to COVID-19 are associated with diabetes?',
+  'Is remdesivir an effective treatment for COVID-19?',
 ];
 
 const TallDivider = styled(Divider)`
@@ -111,7 +114,7 @@ function SearchSuggestions() {
       <h4>Try searching for...</h4>
       <List>
         {shuffle(sampleQueries)
-          .slice(0, 3)
+          .slice(0, 4)
           .map((query, i) => (
             <List.Item key={i}>
               <Link to={'/search?query=' + encodeURIComponent(query)}>

--- a/src/App/Search/SearchOptions.js
+++ b/src/App/Search/SearchOptions.js
@@ -16,23 +16,19 @@ const Container = styled.div`
 
 const fieldsets = [
   {
-    text: 'title and abstract',
-    value: 'default',
+    text: 'title, abstract and full text',
+    value: 'allt5',
   },
   {
-    text: 'title, abstract and full text',
-    value: 'all',
+    text: 'title, abstract',
+    value: 'default',
   },
 ];
 
 const rankings = [
   {
-    text: 'Vespa BM25',
-    value: 'bm25',
-  },
-  {
-    text: 'Vespa nativeRank',
-    value: 'default',
+    text: 'text ranking',
+    value: 'bm25t5',
   },
   {
     text: 'date',

--- a/src/App/Search/Utils.js
+++ b/src/App/Search/Utils.js
@@ -59,6 +59,7 @@ const generateApiQueryParams = () => {
   ].forEach(q => query.delete(q));
   if (filter) query.set('filter', filter);
   if (ranking) query.set('ranking.profile', ranking);
+  else query.set('ranking.profile','bm25t5');
   if (fieldset) query.set('model.defaultIndex', fieldset);
   query.set('select', select);
 


### PR DESCRIPTION
Updated query examples
Show 4 examples instead of 3

![image](https://user-images.githubusercontent.com/20928528/79987672-01f17a00-84ae-11ea-8607-c734d3a5fc16.png)

Only two options listed, either search by text ranking or by date. Less confusion I believe. 

![image](https://user-images.githubusercontent.com/20928528/79987779-20577580-84ae-11ea-88ee-6c8dc3c34ed5.png)


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
