### PR TITLE
Allow empty commits to gh-pages

### DIFF
--- a/.github/workflows/deploy-ui.yaml
+++ b/.github/workflows/deploy-ui.yaml
@@ -82,6 +82,6 @@ jobs:
         git diff
         rm -rf ../build
         git add .
-        git commit -m "Publish to gh-pages branch $(date -Is)"
+        git commit --allow-empty -m "Publish to gh-pages branch $(date -Is)"
         git remote set-url origin "https://x-access-token:${DEPLOY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git push origin gh-pages


### PR DESCRIPTION
The problem deploying #118 was that the dependency upgrade didn't actually change the built code (updated code paths were not used by the project and were there excluded after tree shaking in `yarn build`)